### PR TITLE
Unity5.2に対応

### DIFF
--- a/Assets/uGuiEffectTool/UIEffect/BlendColor.cs
+++ b/Assets/uGuiEffectTool/UIEffect/BlendColor.cs
@@ -27,7 +27,21 @@ namespace UiEffect
 
         Graphic graphic;
 
-        public override void ModifyVertices (List<UIVertex> vList)
+        public override void ModifyMesh(VertexHelper vh)
+        {
+            if (!this.IsActive())
+                return;
+
+            List<UIVertex> list = new List<UIVertex>();
+            vh.GetUIVertexStream(list);
+
+            ModifyVertices(list);
+
+            vh.Clear();
+            vh.AddUIVertexTriangleStream(list);
+        }
+
+        public void ModifyVertices (List<UIVertex> vList)
         {
             if (IsActive () == false || vList == null || vList.Count == 0) {
                 return;

--- a/Assets/uGuiEffectTool/UIEffect/GradientColor.cs
+++ b/Assets/uGuiEffectTool/UIEffect/GradientColor.cs
@@ -29,7 +29,21 @@ namespace UiEffect
 
         Graphic graphic;
 
-        public override void ModifyVertices (List<UIVertex> vList)
+        public override void ModifyMesh(VertexHelper vh)
+        {
+            if (!this.IsActive())
+                return;
+
+            List<UIVertex> list = new List<UIVertex>();
+            vh.GetUIVertexStream(list);
+
+            ModifyVertices(list);
+
+            vh.Clear();
+            vh.AddUIVertexTriangleStream(list);
+        }
+
+        public void ModifyVertices (List<UIVertex> vList)
         {
             if (IsActive () == false || vList == null || vList.Count == 0) {
                 return;


### PR DESCRIPTION
Unity5.2ではModifyVerticesがオーバーライドできなくなったようなので、
http://forum.unity3d.com/threads/unity-5-2-ui-performance-seems-much-worse.353650/
を参考に、ModifyMeshのほうをオーバーライドしてそこで今あるModifyVerticesで実処理をする形にしました。
